### PR TITLE
Add add-ons APIs

### DIFF
--- a/zap/access-control_generated.go
+++ b/zap/access-control_generated.go
@@ -1,0 +1,71 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type AccessControl struct {
+	c *Client
+}
+
+// Gets the Access Control scan progress (percentage integer) for the given context ID.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AccessControl) GetScanProgress(contextid string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId": contextid,
+	}
+	return a.c.Request("accessControl/view/getScanProgress/", m)
+}
+
+// Gets the Access Control scan status (description string) for the given context ID.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AccessControl) GetScanStatus(contextid string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId": contextid,
+	}
+	return a.c.Request("accessControl/view/getScanStatus/", m)
+}
+
+// Starts an Access Control scan with the given context ID and user ID. (Optional parameters: user ID for Unauthenticated user, boolean identifying whether or not Alerts are raised, and the Risk level for the Alerts.) [This assumes the Access Control rules were previously established via ZAP gui and the necessary Context exported/imported.]
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AccessControl) Scan(contextid string, userid string, scanasunauthuser string, raisealert string, alertrisklevel string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId":        contextid,
+		"userId":           userid,
+		"scanAsUnAuthUser": scanasunauthuser,
+		"raiseAlert":       raisealert,
+		"alertRiskLevel":   alertrisklevel,
+	}
+	return a.c.Request("accessControl/action/scan/", m)
+}
+
+// Generates an Access Control report for the given context ID and saves it based on the provided filename (path).
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AccessControl) WriteHTMLreport(contextid string, filename string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId": contextid,
+		"fileName":  filename,
+	}
+	return a.c.Request("accessControl/action/writeHTMLreport/", m)
+}

--- a/zap/ajax-spider_generated.go
+++ b/zap/ajax-spider_generated.go
@@ -1,0 +1,263 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+import "strconv"
+
+type AjaxSpider struct {
+	c *Client
+}
+
+// Gets the current status of the crawler. Actual values are Stopped and Running.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) Status() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/status/", nil)
+}
+
+// Gets the current results of the crawler.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) Results(start string, count string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"start": start,
+		"count": count,
+	}
+	return a.c.Request("ajaxSpider/view/results/", m)
+}
+
+// Gets the number of resources found.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) NumberOfResults() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/numberOfResults/", nil)
+}
+
+// Gets the full crawled content detected by the AJAX Spider. Returns a set of values based on 'inScope' URLs, 'outOfScope' URLs, and 'errors' encountered during the last/current run of the AJAX Spider.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) FullResults() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/fullResults/", nil)
+}
+
+// Gets the configured browser to use for crawling.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionBrowserId() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionBrowserId/", nil)
+}
+
+// Gets the time to wait after an event (in milliseconds). For example: the wait delay after the cursor hovers over an element, in order for a menu to display, etc.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionEventWait() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionEventWait/", nil)
+}
+
+// Gets the configured value for the max crawl depth.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionMaxCrawlDepth() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionMaxCrawlDepth/", nil)
+}
+
+// Gets the configured value for the maximum crawl states allowed.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionMaxCrawlStates() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionMaxCrawlStates/", nil)
+}
+
+// Gets the configured max duration of the crawl, the value is in minutes.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionMaxDuration() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionMaxDuration/", nil)
+}
+
+// Gets the configured number of browsers to be used.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionNumberOfBrowsers() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionNumberOfBrowsers/", nil)
+}
+
+// Gets the configured time to wait after reloading the page, this value is in milliseconds.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionReloadWait() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionReloadWait/", nil)
+}
+
+// Gets the configured value for 'Click Default Elements Only', HTML elements such as 'a', 'button', 'input', all associated with some action or links on the page.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionClickDefaultElems() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionClickDefaultElems/", nil)
+}
+
+// Gets the value configured for the AJAX Spider to know if it should click on the elements only once.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionClickElemsOnce() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionClickElemsOnce/", nil)
+}
+
+// Gets if the AJAX Spider will use random values in form fields when crawling, if set to true.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) OptionRandomInputs() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/view/optionRandomInputs/", nil)
+}
+
+// Runs the AJAX Spider against a given target.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) Scan(url string, inscope string, contextname string, subtreeonly string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"url":         url,
+		"inScope":     inscope,
+		"contextName": contextname,
+		"subtreeOnly": subtreeonly,
+	}
+	return a.c.Request("ajaxSpider/action/scan/", m)
+}
+
+// Runs the AJAX Spider from the perspective of a User of the web application.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) ScanAsUser(contextname string, username string, url string, subtreeonly string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextName": contextname,
+		"userName":    username,
+		"url":         url,
+		"subtreeOnly": subtreeonly,
+	}
+	return a.c.Request("ajaxSpider/action/scanAsUser/", m)
+}
+
+// Stops the AJAX Spider.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) Stop() (map[string]interface{}, error) {
+	return a.c.Request("ajaxSpider/action/stop/", nil)
+}
+
+// Sets the configuration of the AJAX Spider to use one of the supported browsers.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionBrowserId(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return a.c.Request("ajaxSpider/action/setOptionBrowserId/", m)
+}
+
+// Sets whether or not the the AJAX Spider will only click on the default HTML elements.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionClickDefaultElems(boolean bool) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Boolean": strconv.FormatBool(boolean),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionClickDefaultElems/", m)
+}
+
+// When enabled, the crawler attempts to interact with each element (e.g., by clicking) only once.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionClickElemsOnce(boolean bool) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Boolean": strconv.FormatBool(boolean),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionClickElemsOnce/", m)
+}
+
+// Sets the time to wait after an event (in milliseconds). For example: the wait delay after the cursor hovers over an element, in order for a menu to display, etc.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionEventWait(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionEventWait/", m)
+}
+
+// Sets the maximum depth that the crawler can reach.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionMaxCrawlDepth(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionMaxCrawlDepth/", m)
+}
+
+// Sets the maximum number of states that the crawler should crawl.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionMaxCrawlStates(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionMaxCrawlStates/", m)
+}
+
+// The maximum time that the crawler is allowed to run.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionMaxDuration(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionMaxDuration/", m)
+}
+
+// Sets the number of windows to be used by AJAX Spider.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionNumberOfBrowsers(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionNumberOfBrowsers/", m)
+}
+
+// When enabled, inserts random values into form fields.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionRandomInputs(boolean bool) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Boolean": strconv.FormatBool(boolean),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionRandomInputs/", m)
+}
+
+// Sets the time to wait after the page is loaded before interacting with it.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AjaxSpider) SetOptionReloadWait(i int) (map[string]interface{}, error) {
+	m := map[string]string{
+		"Integer": strconv.Itoa(i),
+	}
+	return a.c.Request("ajaxSpider/action/setOptionReloadWait/", m)
+}

--- a/zap/alert-filter_generated.go
+++ b/zap/alert-filter_generated.go
@@ -1,0 +1,125 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type AlertFilter struct {
+	c *Client
+}
+
+// Lists the alert filters of the context with the given ID.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) AlertFilterList(contextid string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId": contextid,
+	}
+	return a.c.Request("alertFilter/view/alertFilterList/", m)
+}
+
+// Lists the global alert filters.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) GlobalAlertFilterList() (map[string]interface{}, error) {
+	return a.c.Request("alertFilter/view/globalAlertFilterList/", nil)
+}
+
+// Adds a new alert filter for the context with the given ID.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) AddAlertFilter(contextid string, ruleid string, newlevel string, url string, urlisregex string, parameter string, enabled string, parameterisregex string, attack string, attackisregex string, evidence string, evidenceisregex string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId":        contextid,
+		"ruleId":           ruleid,
+		"newLevel":         newlevel,
+		"url":              url,
+		"urlIsRegex":       urlisregex,
+		"parameter":        parameter,
+		"enabled":          enabled,
+		"parameterIsRegex": parameterisregex,
+		"attack":           attack,
+		"attackIsRegex":    attackisregex,
+		"evidence":         evidence,
+		"evidenceIsRegex":  evidenceisregex,
+	}
+	return a.c.Request("alertFilter/action/addAlertFilter/", m)
+}
+
+// Removes an alert filter from the context with the given ID.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) RemoveAlertFilter(contextid string, ruleid string, newlevel string, url string, urlisregex string, parameter string, enabled string, parameterisregex string, attack string, attackisregex string, evidence string, evidenceisregex string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"contextId":        contextid,
+		"ruleId":           ruleid,
+		"newLevel":         newlevel,
+		"url":              url,
+		"urlIsRegex":       urlisregex,
+		"parameter":        parameter,
+		"enabled":          enabled,
+		"parameterIsRegex": parameterisregex,
+		"attack":           attack,
+		"attackIsRegex":    attackisregex,
+		"evidence":         evidence,
+		"evidenceIsRegex":  evidenceisregex,
+	}
+	return a.c.Request("alertFilter/action/removeAlertFilter/", m)
+}
+
+// Adds a new global alert filter.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) AddGlobalAlertFilter(ruleid string, newlevel string, url string, urlisregex string, parameter string, enabled string, parameterisregex string, attack string, attackisregex string, evidence string, evidenceisregex string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"ruleId":           ruleid,
+		"newLevel":         newlevel,
+		"url":              url,
+		"urlIsRegex":       urlisregex,
+		"parameter":        parameter,
+		"enabled":          enabled,
+		"parameterIsRegex": parameterisregex,
+		"attack":           attack,
+		"attackIsRegex":    attackisregex,
+		"evidence":         evidence,
+		"evidenceIsRegex":  evidenceisregex,
+	}
+	return a.c.Request("alertFilter/action/addGlobalAlertFilter/", m)
+}
+
+// Removes a global alert filter.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (a AlertFilter) RemoveGlobalAlertFilter(ruleid string, newlevel string, url string, urlisregex string, parameter string, enabled string, parameterisregex string, attack string, attackisregex string, evidence string, evidenceisregex string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"ruleId":           ruleid,
+		"newLevel":         newlevel,
+		"url":              url,
+		"urlIsRegex":       urlisregex,
+		"parameter":        parameter,
+		"enabled":          enabled,
+		"parameterIsRegex": parameterisregex,
+		"attack":           attack,
+		"attackIsRegex":    attackisregex,
+		"evidence":         evidence,
+		"evidenceIsRegex":  evidenceisregex,
+	}
+	return a.c.Request("alertFilter/action/removeGlobalAlertFilter/", m)
+}

--- a/zap/exportreport_generated.go
+++ b/zap/exportreport_generated.go
@@ -1,0 +1,45 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Exportreport struct {
+	c *Client
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (e Exportreport) Formats() (map[string]interface{}, error) {
+	return e.c.Request("exportreport/view/formats/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (e Exportreport) Generate(absolutepath string, fileextension string, sourcedetails string, alertseverity string, alertdetails string, scanid string, includepassivealerts string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"absolutePath":         absolutepath,
+		"fileExtension":        fileextension,
+		"sourceDetails":        sourcedetails,
+		"alertSeverity":        alertseverity,
+		"alertDetails":         alertdetails,
+		"scanId":               scanid,
+		"includePassiveAlerts": includepassivealerts,
+	}
+	return e.c.Request("exportreport/action/generate/", m)
+}

--- a/zap/import-log-files_generated.go
+++ b/zap/import-log-files_generated.go
@@ -1,0 +1,67 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type ImportLogFiles struct {
+	c *Client
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (i ImportLogFiles) ImportZAPLogFromFile(filepath string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"FilePath": filepath,
+	}
+	return i.c.Request("importLogFiles/action/ImportZAPLogFromFile/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (i ImportLogFiles) ImportModSecurityLogFromFile(filepath string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"FilePath": filepath,
+	}
+	return i.c.Request("importLogFiles/action/ImportModSecurityLogFromFile/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (i ImportLogFiles) ImportZAPHttpRequestResponsePair(httprequest string, httpresponse string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"HTTPRequest":  httprequest,
+		"HTTPResponse": httpresponse,
+	}
+	return i.c.Request("importLogFiles/action/ImportZAPHttpRequestResponsePair/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (i ImportLogFiles) PostModSecurityAuditEvent(auditeventstring string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"AuditEventString": auditeventstring,
+	}
+	return i.c.Request("importLogFiles/action/PostModSecurityAuditEvent/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (i ImportLogFiles) OtherPostModSecurityAuditEvent(auditeventstring string) ([]byte, error) {
+	m := map[string]string{
+		"AuditEventString": auditeventstring,
+	}
+	return i.c.RequestOther("importLogFiles/other/OtherPostModSecurityAuditEvent/", m)
+}

--- a/zap/importurls_generated.go
+++ b/zap/importurls_generated.go
@@ -1,0 +1,36 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Importurls struct {
+	c *Client
+}
+
+// Imports URLs (one per line) from the file with the given file system path.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (i Importurls) Importurls(filepath string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"filePath": filepath,
+	}
+	return i.c.Request("importurls/action/importurls/", m)
+}

--- a/zap/interface.go
+++ b/zap/interface.go
@@ -21,7 +21,10 @@ package zap
 
 // Interface defines the interface a ZAP client should implement
 type Interface interface {
+	AccessControl() *AccessControl
 	Acsrf() *Acsrf
+	AjaxSpider() *AjaxSpider
+	AlertFilter() *AlertFilter
 	Ascan() *Ascan
 	Authentication() *Authentication
 	Authorization() *Authorization
@@ -29,21 +32,47 @@ type Interface interface {
 	Break() *Break
 	Context() *Context
 	Core() *Core
+	Exportreport() *Exportreport
 	ForcedUser() *ForcedUser
 	HttpSessions() *HttpSessions
+	ImportLogFiles() *ImportLogFiles
+	Importurls() *Importurls
 	Openapi() *Openapi
 	Params() *Params
+	Pnh() *Pnh
 	Pscan() *Pscan
+	Replacer() *Replacer
+	Reveal() *Reveal
+	Revisit() *Revisit
 	Script() *Script
 	Search() *Search
+	Selenium() *Selenium
+	Soap() *Soap
 	Spider() *Spider
 	Stats() *Stats
 	Users() *Users
+	Wappalyzer() *Wappalyzer
+	Websocket() *Websocket
+}
+
+// AccessControl() returns a AccessControl client
+func (c *Client) AccessControl() *AccessControl {
+	return &AccessControl{c}
 }
 
 // Acsrf() returns a Acsrf client
 func (c *Client) Acsrf() *Acsrf {
 	return &Acsrf{c}
+}
+
+// AjaxSpider() returns a AjaxSpider client
+func (c *Client) AjaxSpider() *AjaxSpider {
+	return &AjaxSpider{c}
+}
+
+// AlertFilter() returns a AlertFilter client
+func (c *Client) AlertFilter() *AlertFilter {
+	return &AlertFilter{c}
 }
 
 // Ascan() returns a Ascan client
@@ -81,6 +110,11 @@ func (c *Client) Core() *Core {
 	return &Core{c}
 }
 
+// Exportreport() returns a Exportreport client
+func (c *Client) Exportreport() *Exportreport {
+	return &Exportreport{c}
+}
+
 // ForcedUser() returns a ForcedUser client
 func (c *Client) ForcedUser() *ForcedUser {
 	return &ForcedUser{c}
@@ -89,6 +123,16 @@ func (c *Client) ForcedUser() *ForcedUser {
 // HttpSessions() returns a HttpSessions client
 func (c *Client) HttpSessions() *HttpSessions {
 	return &HttpSessions{c}
+}
+
+// ImportLogFiles() returns a ImportLogFiles client
+func (c *Client) ImportLogFiles() *ImportLogFiles {
+	return &ImportLogFiles{c}
+}
+
+// Importurls() returns a Importurls client
+func (c *Client) Importurls() *Importurls {
+	return &Importurls{c}
 }
 
 // Openapi() returns a Openapi clinet
@@ -101,9 +145,29 @@ func (c *Client) Params() *Params {
 	return &Params{c}
 }
 
+// Pnh() returns a Pnh client
+func (c *Client) Pnh() *Pnh {
+	return &Pnh{c}
+}
+
 // Pscan() returns a Pscan client
 func (c *Client) Pscan() *Pscan {
 	return &Pscan{c}
+}
+
+// Replacer() returns a Replacer client
+func (c *Client) Replacer() *Replacer {
+	return &Replacer{c}
+}
+
+// Reveal() returns a Reveal client
+func (c *Client) Reveal() *Reveal {
+	return &Reveal{c}
+}
+
+// Revisit() returns a Revisit client
+func (c *Client) Revisit() *Revisit {
+	return &Revisit{c}
 }
 
 // Script() returns a Script client
@@ -114,6 +178,16 @@ func (c *Client) Script() *Script {
 // Search() returns a Search client
 func (c *Client) Search() *Search {
 	return &Search{c}
+}
+
+// Selenium() returns a Selenium client
+func (c *Client) Selenium() *Selenium {
+	return &Selenium{c}
+}
+
+// Soap() returns a Soap client
+func (c *Client) Soap() *Soap {
+	return &Soap{c}
 }
 
 // Spider() returns a Spider client
@@ -129,4 +203,14 @@ func (c *Client) Stats() *Stats {
 // Users() returns a Users client
 func (c *Client) Users() *Users {
 	return &Users{c}
+}
+
+// Wappalyzer() returns a Wappalyzer client
+func (c *Client) Wappalyzer() *Wappalyzer {
+	return &Wappalyzer{c}
+}
+
+// Websocket() returns a Websocket client
+func (c *Client) Websocket() *Websocket {
+	return &Websocket{c}
 }

--- a/zap/pnh_generated.go
+++ b/zap/pnh_generated.go
@@ -1,0 +1,79 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Pnh struct {
+	c *Client
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Monitor(id string, message string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"id":      id,
+		"message": message,
+	}
+	return p.c.Request("pnh/action/monitor/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Oracle(id string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"id": id,
+	}
+	return p.c.Request("pnh/action/oracle/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) StartMonitoring(url string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"url": url,
+	}
+	return p.c.Request("pnh/action/startMonitoring/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) StopMonitoring(id string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"id": id,
+	}
+	return p.c.Request("pnh/action/stopMonitoring/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Pnh() ([]byte, error) {
+	return p.c.RequestOther("pnh/other/pnh/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Manifest() ([]byte, error) {
+	return p.c.RequestOther("pnh/other/manifest/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Service() ([]byte, error) {
+	return p.c.RequestOther("pnh/other/service/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (p Pnh) Fx_pnhxpi() ([]byte, error) {
+	return p.c.RequestOther("pnh/other/fx_pnh.xpi/", nil)
+}

--- a/zap/replacer_generated.go
+++ b/zap/replacer_generated.go
@@ -1,0 +1,70 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Replacer struct {
+	c *Client
+}
+
+// Returns full details of all of the rules
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Replacer) Rules() (map[string]interface{}, error) {
+	return r.c.Request("replacer/view/rules/", nil)
+}
+
+// Adds a replacer rule. For the parameters: desc is a user friendly description, enabled is true or false, matchType is one of [REQ_HEADER, REQ_HEADER_STR, REQ_BODY_STR, RESP_HEADER, RESP_HEADER_STR, RESP_BODY_STR], matchRegex should be true if the matchString should be treated as a regex otherwise false, matchString is the string that will be matched against, replacement is the replacement string, initiators may be blank (for all initiators) or a comma separated list of integers as defined in <a href="https://github.com/zaproxy/zaproxy/blob/develop/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java">HttpSender</a>
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Replacer) AddRule(description string, enabled string, matchtype string, matchregex string, matchstring string, replacement string, initiators string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"description": description,
+		"enabled":     enabled,
+		"matchType":   matchtype,
+		"matchRegex":  matchregex,
+		"matchString": matchstring,
+		"replacement": replacement,
+		"initiators":  initiators,
+	}
+	return r.c.Request("replacer/action/addRule/", m)
+}
+
+// Removes the rule with the given description
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Replacer) RemoveRule(description string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"description": description,
+	}
+	return r.c.Request("replacer/action/removeRule/", m)
+}
+
+// Enables or disables the rule with the given description based on the bool parameter
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Replacer) SetEnabled(description string, bool string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"description": description,
+		"bool":        bool,
+	}
+	return r.c.Request("replacer/action/setEnabled/", m)
+}

--- a/zap/reveal_generated.go
+++ b/zap/reveal_generated.go
@@ -1,0 +1,43 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Reveal struct {
+	c *Client
+}
+
+// Tells if shows hidden fields and enables disabled fields
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Reveal) Reveal() (map[string]interface{}, error) {
+	return r.c.Request("reveal/view/reveal/", nil)
+}
+
+// Sets if shows hidden fields and enables disabled fields
+//
+// This component is optional and therefore the API will only work if it is installed
+func (r Reveal) SetReveal(reveal string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"reveal": reveal,
+	}
+	return r.c.Request("reveal/action/setReveal/", m)
+}

--- a/zap/revisit_generated.go
+++ b/zap/revisit_generated.go
@@ -1,0 +1,49 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Revisit struct {
+	c *Client
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (r Revisit) RevisitList() (map[string]interface{}, error) {
+	return r.c.Request("revisit/view/revisitList/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (r Revisit) RevisitSiteOn(site string, starttime string, endtime string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"site":      site,
+		"startTime": starttime,
+		"endTime":   endtime,
+	}
+	return r.c.Request("revisit/action/revisitSiteOn/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (r Revisit) RevisitSiteOff(site string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"site": site,
+	}
+	return r.c.Request("revisit/action/revisitSiteOff/", m)
+}

--- a/zap/selenium_generated.go
+++ b/zap/selenium_generated.go
@@ -1,0 +1,107 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Selenium struct {
+	c *Client
+}
+
+// Returns the current path to ChromeDriver
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) OptionChromeDriverPath() (map[string]interface{}, error) {
+	return s.c.Request("selenium/view/optionChromeDriverPath/", nil)
+}
+
+// Returns the current path to Firefox binary
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) OptionFirefoxBinaryPath() (map[string]interface{}, error) {
+	return s.c.Request("selenium/view/optionFirefoxBinaryPath/", nil)
+}
+
+// Returns the current path to Firefox driver (geckodriver)
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) OptionFirefoxDriverPath() (map[string]interface{}, error) {
+	return s.c.Request("selenium/view/optionFirefoxDriverPath/", nil)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) OptionIeDriverPath() (map[string]interface{}, error) {
+	return s.c.Request("selenium/view/optionIeDriverPath/", nil)
+}
+
+// Returns the current path to PhantomJS binary
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) OptionPhantomJsBinaryPath() (map[string]interface{}, error) {
+	return s.c.Request("selenium/view/optionPhantomJsBinaryPath/", nil)
+}
+
+// Sets the current path to ChromeDriver
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) SetOptionChromeDriverPath(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return s.c.Request("selenium/action/setOptionChromeDriverPath/", m)
+}
+
+// Sets the current path to Firefox binary
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) SetOptionFirefoxBinaryPath(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return s.c.Request("selenium/action/setOptionFirefoxBinaryPath/", m)
+}
+
+// Sets the current path to Firefox driver (geckodriver)
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) SetOptionFirefoxDriverPath(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return s.c.Request("selenium/action/setOptionFirefoxDriverPath/", m)
+}
+
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) SetOptionIeDriverPath(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return s.c.Request("selenium/action/setOptionIeDriverPath/", m)
+}
+
+// Sets the current path to PhantomJS binary
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Selenium) SetOptionPhantomJsBinaryPath(str string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"String": str,
+	}
+	return s.c.Request("selenium/action/setOptionPhantomJsBinaryPath/", m)
+}

--- a/zap/soap_generated.go
+++ b/zap/soap_generated.go
@@ -1,0 +1,46 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Soap struct {
+	c *Client
+}
+
+// Import a WSDL definition from local file.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Soap) ImportFile(file string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"file": file,
+	}
+	return s.c.Request("soap/action/importFile/", m)
+}
+
+// Import a WSDL definition from a URL.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (s Soap) ImportUrl(url string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"url": url,
+	}
+	return s.c.Request("soap/action/importUrl/", m)
+}

--- a/zap/wappalyzer_generated.go
+++ b/zap/wappalyzer_generated.go
@@ -1,0 +1,50 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Wappalyzer struct {
+	c *Client
+}
+
+// Lists all the sites recognized by the wappalyzer addon.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Wappalyzer) ListSites() (map[string]interface{}, error) {
+	return w.c.Request("wappalyzer/view/listSites/", nil)
+}
+
+// Lists all sites and their associated applications (technologies).
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Wappalyzer) ListAll() (map[string]interface{}, error) {
+	return w.c.Request("wappalyzer/view/listAll/", nil)
+}
+
+// Lists all the applications (technologies) associated with a specific site.
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Wappalyzer) ListSite(site string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"site": site,
+	}
+	return w.c.Request("wappalyzer/view/listSite/", m)
+}

--- a/zap/websocket_generated.go
+++ b/zap/websocket_generated.go
@@ -1,0 +1,87 @@
+// Zed Attack Proxy (ZAP) and its related class files.
+//
+// ZAP is an HTTP/HTTPS proxy for assessing web application security.
+//
+// Copyright 2017 the ZAP development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *** This file was automatically generated. ***
+//
+
+package zap
+
+type Websocket struct {
+	c *Client
+}
+
+// Returns all of the registered web socket channels
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) Channels() (map[string]interface{}, error) {
+	return w.c.Request("websocket/view/channels/", nil)
+}
+
+// Returns full details of the message specified by the channelId and messageId
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) Message(channelid string, messageid string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"channelId": channelid,
+		"messageId": messageid,
+	}
+	return w.c.Request("websocket/view/message/", m)
+}
+
+// Returns a list of all of the messages that meet the given criteria (all optional), where channelId is a channel identifier, start is the offset to start returning messages from (starting from 0), count is the number of messages to return (default no limit) and payloadPreviewLength is the maximum number bytes to return for the payload contents
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) Messages(channelid string, start string, count string, payloadpreviewlength string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"channelId":            channelid,
+		"start":                start,
+		"count":                count,
+		"payloadPreviewLength": payloadpreviewlength,
+	}
+	return w.c.Request("websocket/view/messages/", m)
+}
+
+// Returns a text representation of an intercepted websockets message
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) BreakTextMessage() (map[string]interface{}, error) {
+	return w.c.Request("websocket/view/breakTextMessage/", nil)
+}
+
+// Sends the specified message on the channel specified by channelId, if outgoing is 'True' then the message will be sent to the server and if it is 'False' then it will be sent to the client
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) SendTextMessage(channelid string, outgoing string, message string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"channelId": channelid,
+		"outgoing":  outgoing,
+		"message":   message,
+	}
+	return w.c.Request("websocket/action/sendTextMessage/", m)
+}
+
+// Sets the text message for an intercepted websockets message
+//
+// This component is optional and therefore the API will only work if it is installed
+func (w Websocket) SetBreakTextMessage(message string, outgoing string) (map[string]interface{}, error) {
+	m := map[string]string{
+		"message":  message,
+		"outgoing": outgoing,
+	}
+	return w.c.Request("websocket/action/setBreakTextMessage/", m)
+}


### PR DESCRIPTION
Add the APIs of the following add-ons:
 - Access Control Testing
 - Ajax Spider
 - Alert Filters
 - Export Report
 - Import files containing URLs
 - Log File Importer
 - Plug-n-Hack Configuration
 - Replacer
 - Reveal
 - Revisit
 - Selenium
 - SOAP
 - Wappalyzer - Technology Detection
 - WebSockets
