### PR TITLE
Close HTTP Client connections by default

### DIFF
--- a/zap/client.go
+++ b/zap/client.go
@@ -129,6 +129,9 @@ func (c *Client) request(path string, queryParams map[string]string) ([]byte, er
 	// add API Key header
 	req.Header.Add(ZAP_API_KEY_HEADER, c.APIKey)
 
+	// Close the connection
+	req.Close = true
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Errored when sending request to the server: %v", err)


### PR DESCRIPTION
Was experiencing an EOF error as response from requests sent using the client. I believe this is due to the http client trying to re-use a previous connection. This was fixed by setting `req.Close` to `true`. 

Signed-off-by: Azunna Ikonne <ikonnea@gmail.com>